### PR TITLE
fix: change response checking to compare statusCode

### DIFF
--- a/packages/frontend/src/components/PassageContainer/index.tsx
+++ b/packages/frontend/src/components/PassageContainer/index.tsx
@@ -28,7 +28,8 @@ export default function PassageContainer() {
     async function newPassageText() {
       const data = await passageApi.getById(Number(passageId));
 
-      if (data && data.statusText === "OK") {
+      // data.statusText returns '' when using https so check on codes instead
+      if (data && data.status >= 200 && data.status < 400) {
         const newPassage = setupPassage(data.data.text);
         setPassage(newPassage);
         setPassageStats(setupPassageStats);

--- a/packages/frontend/src/components/PassageSubmit/index.tsx
+++ b/packages/frontend/src/components/PassageSubmit/index.tsx
@@ -27,7 +27,9 @@ export default function PassageCreate() {
     }
 
     const newPassage = await passageApi.post(userInput);
-    if (newPassage.statusText === "Created") {
+
+    // newPassage.statusText returns '' when using https so check on codes instead
+    if (newPassage.status >= 201 && newPassage.status < 400) {
       setButtonText("Created!");
       setSubmitted(true);
       console.log(newPassage.data);


### PR DESCRIPTION
backend seems to be stripping out statusText over https, codes are behaving as expected so changing the comparison